### PR TITLE
Build layout parsing performance improvement

### DIFF
--- a/Editor/AssetDuplicatesTreeView.cs
+++ b/Editor/AssetDuplicatesTreeView.cs
@@ -56,7 +56,7 @@ namespace Oddworm.EditorFramework.BuildLayoutExplorer
         protected override void OnBuildTree(TreeViewItem rootItem, RichBuildLayout buildLayout)
         {
             var lut = new Dictionary<string, List<RichBuildLayout.Asset>>();
-            foreach (var asset in buildLayout.assets)
+            foreach (var asset in buildLayout.assets.Values)
             {
                 if (!lut.TryGetValue(asset.name, out var list))
                 {

--- a/Editor/AssetsTreeView.cs
+++ b/Editor/AssetsTreeView.cs
@@ -60,7 +60,7 @@ namespace Oddworm.EditorFramework.BuildLayoutExplorer
 
         protected override void OnBuildTree(TreeViewItem rootItem, RichBuildLayout buildLayout)
         {
-            foreach (var asset in buildLayout.assets)
+            foreach (var asset in buildLayout.assets.Values)
             {
                 var assetItem = new AssetItem
                 {

--- a/Editor/BundleTreeView.cs
+++ b/Editor/BundleTreeView.cs
@@ -62,7 +62,7 @@ namespace Oddworm.EditorFramework.BuildLayoutExplorer
 
         protected override void OnBuildTree(TreeViewItem rootItem, RichBuildLayout buildLayout)
         {
-            foreach(var bundle in buildLayout.bundles)
+            foreach(var bundle in buildLayout.bundles.Values)
             {
                 var bundleItem = new BundleItem
                 {


### PR DESCRIPTION
I've replaced some lists that have heavy lookup traffic with dictionaries.
In my case with large build layouts this dropped parse time from >10 minutes (wasn't patient enough to let it run through) to around 20 seconds.
I've kept the OrdinalIgnoreCase comparison mode, even though I don't think it's required (but I may miss some nuance here) and dropping it would let the dictionary use hashes for even faster lookup.