### PR TITLE
Byte sizes need to be parsed with invariant culture

### DIFF
--- a/Editor/BuildLayout.cs
+++ b/Editor/BuildLayout.cs
@@ -3,6 +3,7 @@
 // https://github.com/pschraut/UnityAddressablesBuildLayoutExplorer
 //
 using System.Collections.Generic;
+using System.Globalization;
 using UnityEngine;
 
 namespace Oddworm.EditorFramework
@@ -589,25 +590,25 @@ namespace Oddworm.EditorFramework
                 if (size.EndsWith("GB", System.StringComparison.OrdinalIgnoreCase))
                 {
                     var s = size.Substring(0, size.Length - 2);
-                    return (long)(float.Parse(s) * 1024 * 1024 * 1024);
+                    return (long)(float.Parse(s, CultureInfo.InvariantCulture) * 1024 * 1024 * 1024);
                 }
 
                 if (size.EndsWith("MB", System.StringComparison.OrdinalIgnoreCase))
                 {
                     var s = size.Substring(0, size.Length - 2);
-                    return (long)(float.Parse(s) * 1024 * 1024);
+                    return (long)(float.Parse(s, CultureInfo.InvariantCulture) * 1024 * 1024);
                 }
 
                 if (size.EndsWith("KB", System.StringComparison.OrdinalIgnoreCase))
                 {
                     var s = size.Substring(0, size.Length - 2);
-                    return (long)(float.Parse(s) * 1024);
+                    return (long)(float.Parse(s, CultureInfo.InvariantCulture) * 1024);
                 }
 
                 if (size.EndsWith("B", System.StringComparison.OrdinalIgnoreCase))
                 {
                     var s = size.Substring(0, size.Length - 1);
-                    return long.Parse(s);
+                    return long.Parse(s, CultureInfo.InvariantCulture);
                 }
 
                 return -1;


### PR DESCRIPTION
On systems using a different locale than english, the default locale used to parse floats can produce incorrect numbers from a english-written build layout, e.g. `81.27kb` may be parsed as `8127` kb with a german locale.

To prevent this from happening, machine-readable numbers should always be written and parsed with the `InvariantCulture`. This gives reproducible results regardless of the active locale on the thread.

This change just adds the `InvariantLocale` onto the `float.Parse()` invocations for sizes.